### PR TITLE
Fix undefined constant GLOB_BRACE on Alpine Linux

### DIFF
--- a/src/Utilities/Filesystem.php
+++ b/src/Utilities/Filesystem.php
@@ -288,7 +288,7 @@ class Filesystem implements FilesystemContract
     private function getFiles($pattern)
     {
         $files = $this->filesystem->glob(
-            $this->storagePath.DS.$pattern, GLOB_BRACE
+            $this->storagePath.DS.$pattern, defined('GLOB_BRACE') ? GLOB_BRACE : 0
         );
 
         return array_filter(array_map('realpath', $files));


### PR DESCRIPTION
Fix undefined constant GLOB_BRACE exception on Alpine Linux.  

[https://bugs.php.net/bug.php?id=72095](https://bugs.php.net/bug.php?id=72095)